### PR TITLE
Translate all Chinese comments and docs to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# go-data-checksum 数据核对工具
+# go-data-checksum
 
 ## DESCRIPTION
 go-data-checksum is a high-performance data check tool to verify data integrity between MySQL databases/tables. go-data-checksum supports full data check via primary key and incremental data check via specified time field; supports full field check or specified field check also.
 
-go-data-checksum是一款高性能的MySQL数据库/表数据核对工具。go-data-checksum 可以支持按照主键的全量数据核对，和按照时间字段的增量数据核对；可以支持全字段核对或者指定字段核对。
-go-data-checksum 可以支持跨MySQL实例的多表并行核对，并且支持目标表的数据是源表的超集的场景。核对原理为，计算并比较待核对数据的CRC32值。
 
 ## NEW FEATURES
 
@@ -39,7 +37,7 @@ go build -o bin/go-data-sync cmd/sync/main.go
 
 ## USAGE
 ```
-# 使用帮助
+# Usage help
 ./bin/go-data-checksum --help
 
   -check-column-names string
@@ -604,17 +602,17 @@ go-data-checksum is a high-performance MySQL database/table data verification to
 ### Key Capabilities
 
 #### 1. Comprehensive Data Verification Methods
-- **Primary Key-based Full Data Verification (按照主键的全量数据核对)**: Complete table comparison using primary keys for chunking and ordering
-- **Time Field-based Incremental Verification (按照时间字段的增量数据核对)**: Incremental data checking based on specified timestamp columns for efficient delta comparisons
-- **Full Field Verification (全字段核对)**: Compare all columns in the table for complete data integrity
-- **Selective Field Verification (指定字段核对)**: Compare only specified columns for targeted verification
+- **Primary Key-based Full Data Verification**: Complete table comparison using primary keys for chunking and ordering
+- **Time Field-based Incremental Verification**: Incremental data checking based on specified timestamp columns for efficient delta comparisons
+- **Full Field Verification**: Compare all columns in the table for complete data integrity
+- **Selective Field Verification**: Compare only specified columns for targeted verification
 
 #### 2. Advanced Cross-Instance Support
-- **Multi-Table Parallel Verification (跨MySQL实例的多表并行核对)**: Supports parallel verification of multiple tables across different MySQL instances for improved performance
-- **Superset Data Scenarios (目标表的数据是源表的超集的场景)**: Handles scenarios where target table data is a superset of source table data, allowing for flexible replication validation
+- **Multi-Table Parallel Verification**: Supports parallel verification of multiple tables across different MySQL instances for improved performance
+- **Superset Data Scenarios**: Handles scenarios where target table data is a superset of source table data, allowing for flexible replication validation
 
 #### 3. Technical Implementation
-- **CRC32 Checksum Algorithm (计算并比较待核对数据的CRC32值)**: Uses CRC32 checksums to calculate and compare data integrity values, providing fast and reliable data comparison
+- **CRC32 Checksum Algorithm**: Uses CRC32 checksums to calculate and compare data integrity values, providing fast and reliable data comparison
 - **Chunk-based Processing**: Processes data in configurable chunks to handle large tables efficiently
 - **Automatic Primary Key Detection**: Intelligently selects the best unique key for data chunking and comparison
 - **Retry Mechanisms**: Built-in retry logic for handling transient network or database issues

--- a/cmd/checksum/main.go
+++ b/cmd/checksum/main.go
@@ -20,7 +20,7 @@ import (
 
 var AppVersion string
 
-// ChecksumJob 用于协程池管理
+// ChecksumJob manages the checksum worker pool
 type ChecksumJob struct {
 	ChecksumJobChan chan int
 	wg              *sync.WaitGroup
@@ -33,7 +33,7 @@ func NewChecksumJob(threads int) *ChecksumJob {
 	}
 }
 
-// GenerateTableList 生成源表和目标表对应关系
+// GenerateTableList builds the mapping between source and target tables
 func GenerateTableList(baseContext *types.BaseContext) (err error) {
 	queryWithDatabase := func(databases []string, tablesRegexp string, hint string) (tablesList []string, err error) {
 		var query string
@@ -73,7 +73,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 		return tablesList, nil
 	}
 
-	// 指定源端库表名
+	// Source databases and tables given explicitly
 	if baseContext.SourceDatabases != "" && baseContext.SourceTables != "" {
 		baseContext.SourceDatabaseList = strings.Split(baseContext.SourceDatabases, ",")
 		baseContext.SourceTableList = strings.Split(baseContext.SourceTables, ",")
@@ -83,11 +83,11 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 			}
 		}
 	} else if baseContext.SourceDatabases != "" && baseContext.SourceTables == "" {
-		// 指定源库的所有表
+		// All tables of the specified source databases
 		baseContext.SourceDatabaseList = strings.Split(baseContext.SourceDatabases, ",")
 		baseContext.TableQueryHint = "QueryTableNameWithDatabase"
 	} else if baseContext.SourceTableNameRegexp != "" {
-		// 源表正则匹配
+		// Source tables matched by regular expression
 		baseContext.TableQueryHint = "QueryTableNameWithRegexp"
 	} else {
 		return fmt.Errorf("no source tables specified: use --source-db-name (with optional --source-table-name) or --source-table-regexp")
@@ -104,7 +104,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 
 	baseContext.PairOfSourceAndTargetTables = make(map[string]string, len(baseContext.SourceTableFullNameList))
 	if baseContext.TargetDatabases != "" && baseContext.TargetTables != "" {
-		// 指定目标库表
+		// Target databases and tables given explicitly
 		baseContext.TargetDatabaseList = strings.Split(baseContext.TargetDatabases, ",")
 		baseContext.TargetTableList = strings.Split(baseContext.TargetTables, ",")
 		for _, databaseName := range baseContext.TargetDatabaseList {
@@ -120,7 +120,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 			baseContext.PairOfSourceAndTargetTables[tableName] = baseContext.TargetTableFullNameList[i]
 		}
 	} else if baseContext.TargetDatabaseAddSuffix != "" && baseContext.TargetTableAddSuffix != "" {
-		// 目标库表名加后缀
+		// Suffix both the target database and table names
 		for _, tableName := range baseContext.SourceTableFullNameList {
 			sourceDatabaseName := strings.Split(tableName, ".")[0]
 			sourceTableName := strings.Split(tableName, ".")[1]
@@ -128,7 +128,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 			baseContext.PairOfSourceAndTargetTables[tableName] = targetTableName
 		}
 	} else if baseContext.TargetDatabaseAsSource && baseContext.TargetTableAddSuffix != "" {
-		// 目标库名相同，表名加后缀
+		// Same database name, suffixed table name
 		for _, tableName := range baseContext.SourceTableFullNameList {
 			sourceDatabaseName := strings.Split(tableName, ".")[0]
 			sourceTableName := strings.Split(tableName, ".")[1]
@@ -136,7 +136,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 			baseContext.PairOfSourceAndTargetTables[tableName] = targetTableName
 		}
 	} else if baseContext.TargetDatabaseAddSuffix != "" && baseContext.TargetTableAsSource {
-		// 目标库名加后缀，表名相同
+		// Suffixed database name, same table name
 		for _, tableName := range baseContext.SourceTableFullNameList {
 			sourceDatabaseName := strings.Split(tableName, ".")[0]
 			sourceTableName := strings.Split(tableName, ".")[1]
@@ -144,7 +144,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 			baseContext.PairOfSourceAndTargetTables[tableName] = targetTableName
 		}
 	} else if baseContext.TargetDatabaseAsSource && baseContext.TargetTableAsSource {
-		// 目标库表名与源库表一致
+		// Target database and table names identical to the source
 		for _, tableName := range baseContext.SourceTableFullNameList {
 			targetTableName := tableName
 			baseContext.PairOfSourceAndTargetTables[tableName] = targetTableName
@@ -158,7 +158,7 @@ func GenerateTableList(baseContext *types.BaseContext) (err error) {
 	return nil
 }
 
-// runDifferentialAnalysis 运行记录级差异分析，必要时先解析核对字段和唯一键
+// runDifferentialAnalysis runs the record-level difference analysis, resolving check columns and the unique key first when needed
 func runDifferentialAnalysis(baseContext *types.BaseContext, checksumContext *checksum.ChecksumContext) {
 	baseContext.Log.Infof("Running differential analysis for table pair: %s.%s => %s.%s", checksumContext.PerTableContext.SourceDatabaseName, checksumContext.PerTableContext.SourceTableName, checksumContext.PerTableContext.TargetDatabaseName, checksumContext.PerTableContext.TargetTableName)
 	if checksumContext.CheckColumns == nil {
@@ -179,8 +179,8 @@ func runDifferentialAnalysis(baseContext *types.BaseContext, checksumContext *ch
 	}
 }
 
-// ChecksumPerTable 先判断总记录数，然后逐个分片判断checksum值.
-// 返回该表是否核对一致；每个表只返回一次结果，由调用方负责写入结果通道。
+// ChecksumPerTable first compares total row counts, then verifies chunk checksums one by one.
+// Returns whether the table pair is equal; each table returns exactly one result, which the caller writes to the result channels.
 func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableContext *types.TableContext) (isEqual bool, err error) {
 	startTime := time.Now()
 	var tableCheckDuration time.Duration
@@ -192,7 +192,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 	ChecksumContext := checksum.NewChecksumContext(baseContext, tableContext)
 	baseContext.Log.Infof("Starting check table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 
-	// 先核对全表count(*)值是否一致
+	// First verify the full-table count(*) values match
 	if !baseContext.IgnoreRowCountCheck {
 		baseContext.Log.Debugf("DataChecksumByCount of table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 		_, isMoreCheckNeeded, err := ChecksumContext.DataChecksumByCount()
@@ -200,7 +200,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 			return false, err
 		}
 		if !isMoreCheckNeeded {
-			// 行数不一致：如果开启了差异报告，仍然进行记录级分析
+			// Row counts differ: still run record-level analysis when differential reporting is enabled
 			if baseContext.EnableDifferentialReporting {
 				runDifferentialAnalysis(baseContext, ChecksumContext)
 			}
@@ -210,7 +210,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 		baseContext.Log.Debugf("Ignore DataChecksumByCount of table pair: %s.%s => %s.%s due to IgnoreRowCountCheck=true.", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 	}
 
-	// 判断用户有没有输入checkcolumn，没有则取全表所有字段作为核对字段
+	// Use the user-requested check columns, defaulting to all columns of the table
 	baseContext.Log.Debugf("Get user-request check columns of table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 	if ChecksumContext.CheckColumns == nil {
 		if err := ChecksumContext.GetCheckColumns(); err != nil {
@@ -218,7 +218,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 		}
 	}
 
-	// 获取唯一键、最大最小值
+	// Resolve the unique key and its min/max values
 	baseContext.Log.Debugf("GetUniqueKeys of table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 	if err := ChecksumContext.GetUniqueKeys(); err != nil {
 		return false, err
@@ -232,7 +232,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 		return false, err
 	}
 
-	// 计算checksum值
+	// Compute chunk checksums
 	var hasFurtherRange = true
 	for hasFurtherRange {
 		hasFurtherRange, err = ChecksumContext.CalculateNextIterationRangeEndValues()
@@ -244,7 +244,7 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 		var isChunkChecksumEqual bool
 		var duration time.Duration
 		if hasFurtherRange {
-			// 增加重试机制
+			// Retry to ride out transient errors and replication lag
 			for i := 0; i < int(ChecksumContext.Context.DefaultNumRetries); i++ {
 				if i != 0 {
 					time.Sleep(1 * time.Second)
@@ -290,8 +290,8 @@ func (job *ChecksumJob) ChecksumPerTable(baseContext *types.BaseContext, tableCo
 	return true, nil
 }
 
-// ChecksumPerTableViaTimeColumn 使用指定的时间字段增量核对.
-// 返回该表是否核对一致；每个表只返回一次结果，由调用方负责写入结果通道。
+// ChecksumPerTableViaTimeColumn checks incrementally using the specified time column.
+// Returns whether the table pair is equal; each table returns exactly one result, which the caller writes to the result channels.
 func (job *ChecksumJob) ChecksumPerTableViaTimeColumn(baseContext *types.BaseContext, tableContext *types.TableContext) (isEqual bool, err error) {
 	startTime := time.Now()
 	var tableCheckDuration time.Duration
@@ -303,7 +303,7 @@ func (job *ChecksumJob) ChecksumPerTableViaTimeColumn(baseContext *types.BaseCon
 	ChecksumContext := checksum.NewChecksumContext(baseContext, tableContext)
 	baseContext.Log.Infof("Starting check table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 
-	// 判断用户有没有输入checkcolumn，没有则取全表所有字段作为核对字段
+	// Use the user-requested check columns, defaulting to all columns of the table
 	baseContext.Log.Debugf("Get user-request check columns of table pair: %s.%s => %s.%s .", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 	if ChecksumContext.CheckColumns == nil {
 		if err := ChecksumContext.GetCheckColumns(); err != nil {
@@ -311,20 +311,20 @@ func (job *ChecksumJob) ChecksumPerTableViaTimeColumn(baseContext *types.BaseCon
 		}
 	}
 
-	// 获取时间列、最大最小值
+	// Resolve the time column
 	baseContext.Log.Debugf("GetTimeColumn of table pair: %s.%s => %s.%s.", ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 	if err := ChecksumContext.GetTimeColumn(); err != nil {
 		return false, err
 	}
 	baseContext.Log.Debugf("Time column values range [%s-%s] of table pair: %s.%s => %s.%s .", ChecksumContext.Context.SpecifiedDatetimeRangeBegin, ChecksumContext.Context.SpecifiedDatetimeRangeEnd, ChecksumContext.PerTableContext.SourceDatabaseName, ChecksumContext.PerTableContext.SourceTableName, ChecksumContext.PerTableContext.TargetDatabaseName, ChecksumContext.PerTableContext.TargetTableName)
 
-	// 获取满足TimeRange核对条件的估算行数
+	// Estimate the number of rows within the time range
 	estimatedRows, err := ChecksumContext.EstimateTableRowsViaExplain()
 	if err != nil {
 		return false, err
 	}
 
-	// 计算checksum值
+	// Compute chunk checksums
 	var hasFurtherRange = true
 	for hasFurtherRange {
 		hasFurtherRange, err = ChecksumContext.CalculateNextIterationTimeRange()
@@ -336,7 +336,7 @@ func (job *ChecksumJob) ChecksumPerTableViaTimeColumn(baseContext *types.BaseCon
 		var isChunkChecksumEqual bool
 		var duration time.Duration
 		if hasFurtherRange {
-			// 增加重试机制
+			// Retry to ride out transient errors and replication lag
 			for i := 0; i < int(ChecksumContext.Context.DefaultNumRetries); i++ {
 				if i != 0 {
 					time.Sleep(1 * time.Second)
@@ -383,16 +383,16 @@ func (job *ChecksumJob) ChecksumPerTableViaTimeColumn(baseContext *types.BaseCon
 	return true, nil
 }
 
-// 核对任务
+// checksum runs the check across all table pairs
 func (job *ChecksumJob) checksum(baseContext *types.BaseContext) {
-	// 获取源表和目标表
+	// Build the source and target table pairs
 	if err := GenerateTableList(baseContext); err != nil {
 		baseContext.Log.Errorf("Generating source and target tables failed, %s", err.Error())
 		baseContext.PanicAbort <- err
 		return
 	}
 
-	// 逐个表进行核对, 按顺序去除map的元素
+	// Check tables one by one, iterating the map keys in sorted order
 	tableNum := len(baseContext.PairOfSourceAndTargetTables)
 	tableResultEqualNum := 0
 	baseContext.ChecksumResChan = make(chan bool, tableNum)
@@ -419,7 +419,7 @@ func (job *ChecksumJob) checksum(baseContext *types.BaseContext) {
 
 		job.ChecksumJobChan <- 1
 		job.wg.Add(1)
-		// 使用主键/时间字段核对。每个表只向结果通道写入一次 (result, error)。
+		// Check via primary key or time column. Each table writes exactly one (result, error) pair to the channels.
 		go func() {
 			var isEqual bool
 			var err error
@@ -524,13 +524,13 @@ func main() {
 		baseContext.CloseDB()
 		baseContext.Log.Infof("Finished go-data-checksum. TotalDuration=%+v", time.Since(startTime))
 	}()
-	// 初始化源和目标库连接
+	// Initialize the source and target database connections
 	baseContext.Log.Infof("Starting go-data-checksum %+v...", AppVersion)
 	if err := baseContext.InitDB(); err != nil {
 		baseContext.Log.Fatalf("DB connection initiate failed: %v", err)
 	}
 
-	// 核对任务
+	// Run the check job
 	ChecksumJob := NewChecksumJob(baseContext.ParallelThreads)
 	ChecksumJob.checksum(baseContext)
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -19,7 +19,7 @@ const (
 	NotEqualsComparisonSign           ValueComparisonSign = "!="
 )
 
-// EscapeName will escape a db/table/column/... name by wrapping with backticks(反引号).
+// EscapeName will escape a db/table/column/... name by wrapping with backticks.
 // It is not fool proof. I'm just trying to do the right thing here, not solving
 // SQL injection issues, which should be irrelevant for this tool.
 func EscapeName(name string) string {
@@ -29,7 +29,7 @@ func EscapeName(name string) string {
 	return fmt.Sprintf("`%s`", name)
 }
 
-// buildColumnsPreparedValues 构造columns的prepared values，做一些时区转换和json转换等
+// buildColumnsPreparedValues builds prepared-value placeholders for the columns, applying enum/JSON conversions where needed
 func buildColumnsPreparedValues(columns *types.ColumnList) []string {
 	values := make([]string, columns.Len())
 	for i, column := range columns.Columns() {
@@ -46,7 +46,7 @@ func buildColumnsPreparedValues(columns *types.ColumnList) []string {
 	return values
 }
 
-// buildPreparedValues 构造prepared values
+// buildPreparedValues returns a list of "?" placeholders of the given length
 func buildPreparedValues(length int) []string {
 	values := make([]string, length)
 	for i := 0; i < length; i++ {
@@ -55,15 +55,14 @@ func buildPreparedValues(length int) []string {
 	return values
 }
 
-// 复制slice的值
+// duplicateNames returns a copy of the given names slice
 func duplicateNames(names []string) []string {
 	duplicate := make([]string, len(names))
-	// copy() 可以将一个数组切片复制到另一个数组切片中 copy(destSlice, srcSlice []T) int
 	copy(duplicate, names)
 	return duplicate
 }
 
-// BuildValueComparison 构造比较表达式，譬如 "(column = ?) 或者 (column > ?)"
+// BuildValueComparison builds a comparison expression such as "(column = ?)" or "(column > ?)"
 func BuildValueComparison(column string, value string, comparisonSign ValueComparisonSign) (result string, err error) {
 	if column == "" {
 		return "", fmt.Errorf("empty column in GetValueComparison")
@@ -75,7 +74,7 @@ func BuildValueComparison(column string, value string, comparisonSign ValueCompa
 	return comparison, err
 }
 
-// BuildEqualsComparison 返回所有columns的条件表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
+// BuildEqualsComparison builds the equality condition over all columns, e.g. ((col1 = ?) and (col2 = ?) and (col3 = ?))
 func BuildEqualsComparison(columns []string, values []string) (result string, err error) {
 	if len(columns) == 0 {
 		return "", fmt.Errorf("got 0 columns in GetEqualsComparison")
@@ -86,29 +85,24 @@ func BuildEqualsComparison(columns []string, values []string) (result string, er
 	comparisons := []string{}
 	for i, column := range columns {
 		value := values[i]
-		// EqualsComparisonSign 为 "="
-		// BuildValueComparison 构造比较表达式，譬如 "(column = ?)"
 		comparison, err := BuildValueComparison(column, value, EqualsComparisonSign)
 		if err != nil {
 			return "", err
 		}
 		comparisons = append(comparisons, comparison)
 	}
-	// 返回所有columns的条件表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
 	result = strings.Join(comparisons, " and ")
 	result = fmt.Sprintf("(%s)", result)
 	return result, nil
 }
 
-// BuildEqualsPreparedComparison 构造columns的where条件等值表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
+// BuildEqualsPreparedComparison builds the prepared equality WHERE condition over the columns, e.g. ((col1 = ?) and (col2 = ?) and (col3 = ?))
 func BuildEqualsPreparedComparison(columns []string) (result string, err error) {
-	// buildPreparedValues 构造PreparedValues,这里就是Len(columns)个"?"
 	values := buildPreparedValues(len(columns))
-	// BuildEqualsComparison 返回所有columns的条件表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
 	return BuildEqualsComparison(columns, values)
 }
 
-// BuildSetPreparedClause 构造update语句的set子句，譬如 col1=?, col2=?
+// BuildSetPreparedClause builds the SET clause of an UPDATE statement, e.g. col1=?, col2=?
 func BuildSetPreparedClause(columns *types.ColumnList) (result string, err error) {
 	if columns.Len() == 0 {
 		return "", fmt.Errorf("got 0 columns in BuildSetPreparedClause")
@@ -116,7 +110,7 @@ func BuildSetPreparedClause(columns *types.ColumnList) (result string, err error
 	setTokens := []string{}
 	for _, column := range columns.Columns() {
 		var setToken string
-		// 时区转换成零时区+00:00
+		// convert the timezone to UTC (+00:00)
 		if column.TimezoneConversion != nil {
 			setToken = fmt.Sprintf("%s=convert_tz(?, '%s', '%s')", EscapeName(column.Name), column.TimezoneConversion.ToTimezone, "+00:00")
 		} else if column.EnumToTextConversion {
@@ -131,9 +125,9 @@ func BuildSetPreparedClause(columns *types.ColumnList) (result string, err error
 	return strings.Join(setTokens, ", "), nil
 }
 
-// BuildRangeComparison 构造唯一键的分批范围查询where条件
-// 返回结果类似"result = ((col1 > ?) or ((col1 = ?) and (col2 > ?)) or (((col1 = ?) and (col2 = ?)) and (col3 > ?)) or ((col1 = ?) and (col2 = ?) and (col3 = ?)))"
-// 返回结果类似"explodedArgs = [v1, v1, v2, v1, v2, v3, v1, v2, v3]"
+// BuildRangeComparison builds the chunk-range WHERE condition over the unique key columns.
+// Example result: "((col1 > ?) or ((col1 = ?) and (col2 > ?)) or (((col1 = ?) and (col2 = ?)) and (col3 > ?)) or ((col1 = ?) and (col2 = ?) and (col3 = ?)))"
+// Example explodedArgs: "[v1, v1, v2, v1, v2, v3, v1, v2, v3]"
 func BuildRangeComparison(columns []string, values []string, args []interface{}, comparisonSign ValueComparisonSign) (result string, explodedArgs []interface{}, err error) {
 	if len(columns) == 0 {
 		return "", explodedArgs, fmt.Errorf("got 0 columns in GetRangeComparison")
@@ -157,20 +151,17 @@ func BuildRangeComparison(columns []string, values []string, args []interface{},
 
 	for i, column := range columns {
 		value := values[i]
-		// BuildValueComparison 构造比较表达式，譬如 "(column < ?) 或者 (column > ?)", 这里的comparisonSign只有>或<
 		rangeComparison, err := BuildValueComparison(column, value, comparisonSign)
 		if err != nil {
 			return "", explodedArgs, err
 		}
 		if i > 0 {
-			// BuildEqualsComparison 返回所有columns的条件表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
 			equalitiesComparison, err := BuildEqualsComparison(columns[0:i], values[0:i])
 			if err != nil {
 				return "", explodedArgs, err
 			}
 			comparison := fmt.Sprintf("(%s AND %s)", equalitiesComparison, rangeComparison)
 			comparisons = append(comparisons, comparison)
-			// args[0:i]... 等同于 args[0], args[1], ..., args[i]
 			explodedArgs = append(explodedArgs, args[0:i]...)
 			explodedArgs = append(explodedArgs, args[i])
 		} else {
@@ -180,7 +171,6 @@ func BuildRangeComparison(columns []string, values []string, args []interface{},
 	}
 
 	if includeEquals {
-		// BuildEqualsComparison 返回所有columns的条件表达式，譬如((col1 = ?) and (col2 = ?) and (col3 = ?))
 		comparison, err := BuildEqualsComparison(columns, values)
 		if err != nil {
 			return "", explodedArgs, nil
@@ -193,17 +183,15 @@ func BuildRangeComparison(columns []string, values []string, args []interface{},
 	return result, explodedArgs, nil
 }
 
-// BuildRangePreparedComparison 返回唯一键的分批[上限/下限]范围查询where条件
+// BuildRangePreparedComparison builds the prepared upper/lower chunk-range WHERE condition over the unique key columns
 func BuildRangePreparedComparison(columns *types.ColumnList, args []interface{}, comparisonSign ValueComparisonSign) (result string, explodedArgs []interface{}, err error) {
-	// buildColumnsPreparedValues 构造columns的prepared values，做一些时区转换和json转换等
 	values := buildColumnsPreparedValues(columns)
-	// BuildRangeComparison 构造唯一键的分批范围查询where条件
 	return BuildRangeComparison(columns.Names(), values, args, comparisonSign)
 }
 
-// BuildChunkChecksumSQL 构造分批计算CRC32聚合结果的SQL，或者分批计算每行CRC32值的SQL。
-// 这里分批范围是 (rangeMin, rangeMax] ，第一批是 [rangeMin, rangeMax]
-// 最终SQL类似：select /* dataChecksum */
+// BuildChunkChecksumSQL builds the SQL computing either the aggregated chunk CRC32 (BIT_XOR) or the per-row CRC32 values.
+// The chunk range is (rangeMin, rangeMax]; the first chunk is [rangeMin, rangeMax].
+// The final SQL looks like: select /* dataChecksum */
 //
 //	                  COALESCE(LOWER(CONV(BIT_XOR(cast(crc32(CONCAT_WS('#',id, ftime, c1, c2)) as UNSIGNED)), 10, 16)), 0) as CRC32XOR
 //	               OR COALESCE(LOWER(CONV(cast(crc32(CONCAT_WS('#',id, ftime, c1, c2)) as UNSIGNED), 10, 16)), 0) as CRC32
@@ -211,16 +199,13 @@ func BuildRangePreparedComparison(columns *types.ColumnList, args []interface{},
 //	            where (((col1 > ?) or ((col1 = ?) and (col2 > ?)) or (((col1 = ?) and (col2 = ?)) and (col3 > ?)))
 //		             and ((col1 < ?) or ((col1 = ?) and (col2 < ?)) or (((col1 = ?) and (col2 = ?)) and (col3 < ?)) or ((col1 = ?) and (col2 = ?) and (col3 = ?))))
 func BuildChunkChecksumSQL(databaseName, tableName string, checkColumns, uniqueKeyColumns *types.ColumnList, rangeStartValues, rangeEndValues []string, rangeStartArgs, rangeEndArgs []interface{}, includeRangeStartValues bool, checkLevel int64) (result string, explodedArgs []interface{}, err error) {
-	// 库表名转义
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
 
-	// 复制checkColumns的值到 checkColumns,对列名进行转义
 	checkColumnNames := duplicateNames(checkColumns.Names())
 	for i := range checkColumnNames {
 		checkColumnNames[i] = EscapeName(checkColumnNames[i])
 	}
-	// 源表和影子表共享列(包含重命名列)的字符串表示: sharedCol1, sharedCol2, sharedCol3
 	checkColumnNamesListing := strings.Join(checkColumnNames, "), hex(")
 	var builder strings.Builder
 	builder.WriteString("hex(")
@@ -228,22 +213,20 @@ func BuildChunkChecksumSQL(databaseName, tableName string, checkColumns, uniqueK
 	builder.WriteString(")")
 	checkColumnNamesListing = builder.String()
 
-	// minRangeComparisonSign = ">"，如果包含范围最小值，则为 ">=" 。包含范围最小值的情况是第一次循环插入
+	// ">" normally; ">=" when the range start value is included (first chunk)
 	var minRangeComparisonSign ValueComparisonSign = GreaterThanComparisonSign
 	if includeRangeStartValues {
 		minRangeComparisonSign = GreaterThanOrEqualsComparisonSign
 	}
 
-	// 构造唯一键的分批查询的起始范围where条件.
-	// 构造的SQL条件rangeStartComparison类似：((col1 > ?) or ((col1 = ?) and (col2 > ?)) or (((col1 = ?) and (col2 = ?)) and (col3 > ?)) or ((col1 = ?) and (col2 = ?) and (col3 = ?)))"
+	// Build the range-start WHERE condition over the unique key.
 	rangeStartComparison, rangeExplodedArgs, err := BuildRangeComparison(uniqueKeyColumns.Names(), rangeStartValues, rangeStartArgs, minRangeComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
 
-	// 构造唯一键的分批查询的中止范围where条件.
-	// 构造的SQL条件rangeEndComparison类似：((col1 < ?) or ((col1 = ?) and (col2 < ?)) or (((col1 = ?) and (col2 = ?)) and (col3 < ?)) or ((col1 = ?) and (col2 = ?) and (col3 = ?)))"
+	// Build the range-end WHERE condition over the unique key.
 	rangeEndComparison, rangeExplodedArgs, err := BuildRangeComparison(uniqueKeyColumns.Names(), rangeEndValues, rangeEndArgs, LessThanOrEqualsComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
@@ -263,7 +246,7 @@ func BuildChunkChecksumSQL(databaseName, tableName string, checkColumns, uniqueK
 			databaseName, tableName)
 	}
 
-	// uniqueKeyColumnNames 为唯一键的字段名，uniqueKeyColumnAscending 为唯一键字段名+asc
+	// escaped unique key column names, plus asc ordering expressions
 	uniqueKeyColumnNames := duplicateNames(uniqueKeyColumns.Names())
 	uniqueKeyColumnAscending := make([]string, len(uniqueKeyColumnNames))
 	for i, column := range uniqueKeyColumns.Columns() {
@@ -286,17 +269,16 @@ func BuildChunkChecksumSQL(databaseName, tableName string, checkColumns, uniqueK
 	return result, explodedArgs, nil
 }
 
-// BuildRangeChecksumPreparedQuery 返回分批计算CRC32的checksum值的SQL，这里分批范围是 (rangeMin, rangeMax] ，第一批是 [rangeMin, rangeMax]
+// BuildRangeChecksumPreparedQuery returns the prepared chunked CRC32 checksum SQL; the chunk range is (rangeMin, rangeMax], the first chunk [rangeMin, rangeMax]
 func BuildRangeChecksumPreparedQuery(databaseName, tableName string, checkColumns, uniqueKeyColumns *types.ColumnList, rangeStartArgs, rangeEndArgs []interface{}, includeRangeStartValues bool, checkLevel int64) (result string, explodedArgs []interface{}, err error) {
-	// buildColumnsPreparedValues 构造唯一键的columns的prepared values，做一些时区转换和json转换等
 	rangeStartValues := buildColumnsPreparedValues(uniqueKeyColumns)
 	rangeEndValues := buildColumnsPreparedValues(uniqueKeyColumns)
 	return BuildChunkChecksumSQL(databaseName, tableName, checkColumns, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, includeRangeStartValues, checkLevel)
 }
 
-// BuildTimeRangeChecksumSQL 构造按时间字段分批计算CRC32的SQL。
-// 分批范围是 [rangeBegin, rangeEnd)，最后一批为 [rangeBegin, rangeEnd] (includeRangeEnd=true)。
-// checkLevel=1 返回聚合CRC32XOR(顺序无关)，checkLevel=2 返回逐行CRC32。
+// BuildTimeRangeChecksumSQL builds the chunked CRC32 SQL over a time column.
+// The chunk range is [rangeBegin, rangeEnd); the final chunk is [rangeBegin, rangeEnd] (includeRangeEnd=true).
+// checkLevel=1 returns the aggregated CRC32XOR (order independent); checkLevel=2 returns per-row CRC32 values.
 func BuildTimeRangeChecksumSQL(databaseName, tableName string, checkColumns *types.ColumnList, timeColumnName string, includeRangeEnd bool, checkLevel int64) (result string, err error) {
 	if timeColumnName == "" {
 		return "", fmt.Errorf("empty time column in BuildTimeRangeChecksumSQL")
@@ -345,7 +327,7 @@ func BuildTimeRangeChecksumSQL(databaseName, tableName string, checkColumns *typ
 	return result, nil
 }
 
-// BuildTimeRangeEstimateQuery 构造按时间范围估算行数的EXPLAIN SQL
+// BuildTimeRangeEstimateQuery builds the EXPLAIN SQL used to estimate the row count within a time range
 func BuildTimeRangeEstimateQuery(databaseName, tableName, timeColumnName string) string {
 	return fmt.Sprintf(`
       EXPLAIN select /* dataChecksum */ 1
@@ -355,8 +337,8 @@ func BuildTimeRangeEstimateQuery(databaseName, tableName, timeColumnName string)
 		EscapeName(timeColumnName), EscapeName(timeColumnName))
 }
 
-// BuildUniqueKeyRangeEndPreparedQueryViaOffset 构造分批范围的分批下限值查询SQL
-// 最终SQL类似：select  /* gh-ost db.tab iteration:5 */
+// BuildUniqueKeyRangeEndPreparedQueryViaOffset builds the query that finds the current chunk's upper boundary via LIMIT/OFFSET
+// The final SQL looks like: select /* dataChecksum db.tab iteration:5 */
 //
 //				col1, col2, col3
 //			from
@@ -375,27 +357,24 @@ func BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, tableName string
 	tableName = EscapeName(tableName)
 	indexName = EscapeName(indexName)
 
-	// 包含范围起始值，则为GreaterThanOrEqualsComparisonSign，即">="；不包含范围起始值，则为GreaterThanComparisonSign 即 ">"
+	// ">=" when the range start value is included; ">" otherwise
 	var startRangeComparisonSign ValueComparisonSign = GreaterThanComparisonSign
 	if includeRangeStartValues {
 		startRangeComparisonSign = GreaterThanOrEqualsComparisonSign
 	}
 
-	// 返回唯一键的分批下限范围查询where条件，rangeStartArgs即唯一键各字段传入的值
 	rangeStartComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeStartArgs, startRangeComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
-	// LessThanOrEqualsComparisonSign 即 "<="
-	// 返回唯一键的分批上限范围查询where条件，rangeEndArgs即唯一键各字段传入的值
 	rangeEndComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeEndArgs, LessThanOrEqualsComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
 
-	// uniqueKeyColumnNames 为唯一键的字段名，uniqueKeyColumnAscending 为唯一键字段名+asc，uniqueKeyColumnDescending为唯一键字段名+desc
+	// escaped unique key column names, plus asc/desc ordering expressions
 	uniqueKeyColumnNames := duplicateNames(uniqueKeyColumns.Names())
 	uniqueKeyColumnAscending := make([]string, len(uniqueKeyColumnNames))
 	uniqueKeyColumnDescending := make([]string, len(uniqueKeyColumnNames))
@@ -429,8 +408,8 @@ func BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, tableName string
 	return result, explodedArgs, nil
 }
 
-// BuildUniqueKeyRangeEndPreparedQueryViaTemptable 构造分批范围的分批下限值查询SQL，与BuildUniqueKeyRangeEndPreparedQueryViaOffset稍有差异
-// 最终SQL类似：  select /* dataChecksum db.tab iteration:5 */
+// BuildUniqueKeyRangeEndPreparedQueryViaTemptable builds the chunk upper-boundary query via a derived table; slightly different from the offset variant
+// The final SQL looks like: select /* dataChecksum db.tab iteration:5 */
 //
 //	                    col1, col2, col3
 //					 from (
@@ -455,27 +434,24 @@ func BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, tableName str
 	tableName = EscapeName(tableName)
 	indexName = EscapeName(indexName)
 
-	// 包含范围起始值，则为GreaterThanOrEqualsComparisonSign，即">="；不包含范围起始值，则为GreaterThanComparisonSign 即 ">"
+	// ">=" when the range start value is included; ">" otherwise
 	var startRangeComparisonSign ValueComparisonSign = GreaterThanComparisonSign
 	if includeRangeStartValues {
 		startRangeComparisonSign = GreaterThanOrEqualsComparisonSign
 	}
 
-	// 返回唯一键的分批下限范围查询where条件，rangeStartArgs即唯一键各字段传入的值
 	rangeStartComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeStartArgs, startRangeComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
-	// LessThanOrEqualsComparisonSign 即 "<="
-	// 返回唯一键的分批上限范围查询where条件，rangeEndArgs即唯一键各字段传入的值
 	rangeEndComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeEndArgs, LessThanOrEqualsComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
 
-	// uniqueKeyColumnNames 为唯一键的字段名，uniqueKeyColumnAscending 为唯一键字段名+asc，uniqueKeyColumnDescending为唯一键字段名+desc
+	// escaped unique key column names, plus asc/desc ordering expressions
 	uniqueKeyColumnNames := duplicateNames(uniqueKeyColumns.Names())
 	uniqueKeyColumnAscending := make([]string, len(uniqueKeyColumnNames))
 	uniqueKeyColumnDescending := make([]string, len(uniqueKeyColumnNames))
@@ -513,25 +489,23 @@ func BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, tableName str
 	return result, explodedArgs, nil
 }
 
-// BuildUniqueKeyMinValuesPreparedQuery 构造查询唯一键最小值的SQL
+// BuildUniqueKeyMinValuesPreparedQuery builds the SQL fetching the unique key minimum values
 func BuildUniqueKeyMinValuesPreparedQuery(databaseName, tableName string, uniqueKeyColumns *types.ColumnList) (string, error) {
 	return buildUniqueKeyMinMaxValuesPreparedQuery(databaseName, tableName, uniqueKeyColumns, "asc")
 }
 
-// BuildUniqueKeyMaxValuesPreparedQuery 构造查询唯一键最大值的SQL
+// BuildUniqueKeyMaxValuesPreparedQuery builds the SQL fetching the unique key maximum values
 func BuildUniqueKeyMaxValuesPreparedQuery(databaseName, tableName string, uniqueKeyColumns *types.ColumnList) (string, error) {
 	return buildUniqueKeyMinMaxValuesPreparedQuery(databaseName, tableName, uniqueKeyColumns, "desc")
 }
 
-// buildUniqueKeyMinMaxValuesPreparedQuery 生成实际构造语句，在此基础上加上asc/desc排序来构造最小/最大值的对应SQL
+// buildUniqueKeyMinMaxValuesPreparedQuery builds the shared query; asc/desc ordering selects the minimum or maximum values
 func buildUniqueKeyMinMaxValuesPreparedQuery(databaseName, tableName string, uniqueKeyColumns *types.ColumnList, order string) (string, error) {
 	if uniqueKeyColumns.Len() == 0 {
 		return "", fmt.Errorf("got 0 columns in BuildUniqueKeyMinMaxValuesPreparedQuery")
 	}
-	// 使用反引号转义库表名
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
-	// 拷贝uniqueKeyColumns.Names()到新的sliceuniqKeyColumnNames
 	uniqueKeyColumnNames := duplicateNames(uniqueKeyColumns.Names())
 	uniqueKeyColumnOrder := make([]string, len(uniqueKeyColumnNames))
 	for i, column := range uniqueKeyColumns.Columns() {

--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -69,17 +69,17 @@ func NewChecksumContext(context *types.BaseContext, perTableContext *types.Table
 	}
 }
 
-// GetIteration 获取当前核对批次
+// GetIteration returns the current check iteration
 func (ctx *ChecksumContext) GetIteration() int64 {
 	return atomic.LoadInt64(&ctx.PerTableContext.Iteration)
 }
 
-// AddIteration 核对批次累加
+// AddIteration increments the check iteration counter
 func (ctx *ChecksumContext) AddIteration() {
 	atomic.AddInt64(&ctx.PerTableContext.Iteration, 1)
 }
 
-// GetChunkSize 获取chunk大小
+// GetChunkSize returns the configured chunk size
 func (ctx *ChecksumContext) GetChunkSize() int64 {
 	return atomic.LoadInt64(&ctx.Context.ChunkSize)
 }
@@ -91,8 +91,8 @@ func (ctx *ChecksumContext) GetCheckColumns() (err error) {
 		return nil
 	}
 
-	// GROUP_CONCAT()函数默认只能返回1024字节，如果表字段过多可能超过这个限制，需要先设置会话级参数 SET SESSION group_concat_max_len = 10240;
-	// GO的MySQL驱动不能保证前后两个查询是在同一个session，除非使用transaction。
+	// GROUP_CONCAT() returns at most 1024 bytes by default, which wide tables can exceed, so raise group_concat_max_len for the session first.
+	// The Go MySQL driver does not guarantee consecutive queries run on the same session unless a transaction is used.
 	query := `
     select 
       GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION ASC) AS COLUMN_NAMES
@@ -236,7 +236,6 @@ func (ctx *ChecksumContext) GetUniqueKeys() (err error) {
 
 // ReadUniqueKeyRangeMinValues returns the minimum values to be iterated on checksum
 func (ctx *ChecksumContext) ReadUniqueKeyRangeMinValues() (err error) {
-	// 构造获取唯一键最小值的SQL
 	query, err := builder.BuildUniqueKeyMinValuesPreparedQuery(ctx.PerTableContext.SourceDatabaseName, ctx.PerTableContext.SourceTableName, ctx.UniqueKey)
 	if err != nil {
 		return err
@@ -247,10 +246,8 @@ func (ctx *ChecksumContext) ReadUniqueKeyRangeMinValues() (err error) {
 	}
 	defer rows.Close() // Add this to prevent connection leaks
 
-	// UniqueKeyRangeMinValues 为 ColumnValues结构体
 	ctx.UniqueKeyRangeMinValues = types.NewColumnValues(ctx.UniqueKey.Len())
 	for rows.Next() {
-		// SQL查询结构赋值给UniqueKeyRangeMinValues
 		if err = rows.Scan(ctx.UniqueKeyRangeMinValues.ValuesPointers...); err != nil {
 			return err
 		}
@@ -261,7 +258,6 @@ func (ctx *ChecksumContext) ReadUniqueKeyRangeMinValues() (err error) {
 
 // ReadUniqueKeyRangeMaxValues returns the maximum values to be iterated on checksum
 func (ctx *ChecksumContext) ReadUniqueKeyRangeMaxValues() (err error) {
-	// 构造获取唯一键最小值的SQL
 	query, err := builder.BuildUniqueKeyMaxValuesPreparedQuery(ctx.PerTableContext.SourceDatabaseName, ctx.PerTableContext.SourceTableName, ctx.UniqueKey)
 	if err != nil {
 		return err
@@ -272,10 +268,8 @@ func (ctx *ChecksumContext) ReadUniqueKeyRangeMaxValues() (err error) {
 	}
 	defer rows.Close() // Add this to prevent connection leaks
 
-	// UniqueKeyRangeMinValues 为 ColumnValues结构体
 	ctx.UniqueKeyRangeMaxValues = types.NewColumnValues(ctx.UniqueKey.Len())
 	for rows.Next() {
-		// SQL查询结构赋值给UniqueKeyRangeMinValues
 		if err = rows.Scan(ctx.UniqueKeyRangeMaxValues.ValuesPointers...); err != nil {
 			return err
 		}
@@ -284,20 +278,18 @@ func (ctx *ChecksumContext) ReadUniqueKeyRangeMaxValues() (err error) {
 	return rows.Err() // Properly check for errors after scanning
 }
 
-// CalculateNextIterationRangeEndValues 计算下一批次核对的起始值
+// CalculateNextIterationRangeEndValues computes the unique-key range for the next check iteration
 func (ctx *ChecksumContext) CalculateNextIterationRangeEndValues() (hasFurtherRange bool, err error) {
 	ctx.ChecksumIterationRangeMinValues = ctx.ChecksumIterationRangeMaxValues
 	if ctx.ChecksumIterationRangeMinValues == nil {
 		ctx.ChecksumIterationRangeMinValues = ctx.UniqueKeyRangeMinValues
 	}
 
-	// 正常使用BuildUniqueKeyRangeEndPreparedQueryViaOffset返回最大值
-	// 最后一批时使用BuildUniqueKeyRangeEndPreparedQueryViaOffset返回值为空，进入第二次循环，通过BuildUniqueKeyRangeEndPreparedQueryViaTemptable查询最大值
+	// Normally BuildUniqueKeyRangeEndPreparedQueryViaOffset returns the chunk upper bound.
+	// On the final chunk it returns no rows, so the second pass queries the max values via BuildUniqueKeyRangeEndPreparedQueryViaTemptable.
 	for i := 0; i < 2; i++ {
-		// 构造分批范围的分批下限值查询SQL
 		buildFunc := builder.BuildUniqueKeyRangeEndPreparedQueryViaOffset
 		if i == 1 {
-			// BuildUniqueKeyRangeEndPreparedQueryViaTemptable 构造分批范围的分批下限值查询SQL，与BuildUniqueKeyRangeEndPreparedQueryViaOffset稍有差异
 			buildFunc = builder.BuildUniqueKeyRangeEndPreparedQueryViaTemptable
 		}
 		query, explodedArgs, err := buildFunc(
@@ -314,20 +306,16 @@ func (ctx *ChecksumContext) CalculateNextIterationRangeEndValues() (hasFurtherRa
 		if err != nil {
 			return hasFurtherRange, err
 		}
-		// 实际执行查询
 		rows, err := ctx.Context.SourceDB.Query(query, explodedArgs...)
 		if err != nil {
 			return hasFurtherRange, err
 		}
 		defer rows.Close() // Add this to prevent connection leaks
 
-		// NewColumnValues 将ColumnValues结构体的abstractValues的值复制到ValuesPointers
 		iterationRangeMaxValues := types.NewColumnValues(ctx.UniqueKey.Len())
-		// rows.Next() 遍历读取结果期，使用rows.Scan()将结果集存到变量。
-		// 结果集(rows)未关闭前，底层的连接处于繁忙状态。当遍历读到最后一条记录时，会发生一个内部EOF错误，自动调用rows.Close()。
-		// 但是如果提前退出循环，rows不会关闭，连接不会回到连接池中，连接也不会关闭。所以手动关闭非常重要。rows.Close()可以多次调用，是无害操作。
+		// While the result set is open the underlying connection stays busy. Reading past the last row closes it automatically,
+		// but leaving the loop early would leak the connection, so the explicit Close matters (Close is safe to call more than once).
 		for rows.Next() {
-			// Scan()函数将查询结果赋值给iterationRangeMaxValues.ValuesPointers...
 			if err = rows.Scan(iterationRangeMaxValues.ValuesPointers...); err != nil {
 				return hasFurtherRange, err
 			}
@@ -336,7 +324,7 @@ func (ctx *ChecksumContext) CalculateNextIterationRangeEndValues() (hasFurtherRa
 		if err = rows.Err(); err != nil {
 			return hasFurtherRange, err
 		}
-		// 如果还有下一批次结果，将当前查询结果赋值给context的 MigrationIterationRangeMaxValues
+		// If there is a further chunk, store its upper bound in the context
 		if hasFurtherRange {
 			ctx.ChecksumIterationRangeMaxValues = iterationRangeMaxValues
 			return hasFurtherRange, nil
@@ -347,15 +335,15 @@ func (ctx *ChecksumContext) CalculateNextIterationRangeEndValues() (hasFurtherRa
 }
 
 // IterationQueryChecksum issues a chunk-Checksum query on the table.
-// 1. 批次核对：单个批次内聚合结果CRC32值按位异或结果，计算方式：COALESCE(LOWER(CONV(BIT_XOR(cast(crc32(CONCAT_WS('#',C1,C2,C3,Cn)) as UNSIGNED)), 10, 16)), 0)
-// 2. 记录级核对：单个批次内每条记录的CRC32值，判断源端的CRC32是不是目标端的CRC32的子集，计算方式: COALESCE(LOWER(CONV(cast(crc32(CONCAT_WS('#',id, ftime, c1, c2)) as UNSIGNED), 10, 16)), 0)
+// 1. Chunk-level check: XOR-aggregated CRC32 of the rows in the chunk: COALESCE(LOWER(CONV(BIT_XOR(cast(crc32(CONCAT_WS('#',C1,C2,C3,Cn)) as UNSIGNED)), 10, 16)), 0)
+// 2. Row-level check: per-row CRC32 values in the chunk, used to test whether the source rows are a subset of the target rows: COALESCE(LOWER(CONV(cast(crc32(CONCAT_WS('#',id, ftime, c1, c2)) as UNSIGNED), 10, 16)), 0)
 func (ctx *ChecksumContext) IterationQueryChecksum() (isChunkChecksumEqual bool, duration time.Duration, err error) {
 	startTime := time.Now()
 	defer func() {
 		duration = time.Since(startTime)
 	}()
 
-	// 计算CRC32XOR聚合值，还是逐行CRC32值
+	// checkLevel 1 = aggregated CRC32XOR, 2 = per-row CRC32 values
 	var checkLevel int64 = 1
 	if ctx.Context.IsSuperSetAsEqual {
 		checkLevel = 2
@@ -379,13 +367,13 @@ func (ctx *ChecksumContext) IterationQueryChecksum() (isChunkChecksumEqual bool,
 	if reflect.DeepEqual(sourceResult, targetResult) {
 		return true, duration, nil
 	} else if checkLevel == 2 {
-		// 判断有序集subset是否superset的子集,这里可以沿用类似归档排序方式,主要由于主键是可以保证顺序一样
+		// The ordered-subset check works because the unique-key ordering guarantees both sides sort identically
 		return isOrderedSubset(sourceResult, targetResult), duration, nil
 	}
 	return false, duration, nil
 }
 
-// QueryChecksumFunc 获取ChunkChecksum结果(聚合CRC32XOR 或者 逐行CRC32)
+// QueryChecksumFunc fetches the chunk checksum result (aggregated CRC32XOR or per-row CRC32)
 func (ctx *ChecksumContext) QueryChecksumFunc(db *gosql.DB, databaseName, tableName string, uniqueColumn *types.ColumnList, checkLevel int64, ch chan *crc32ResultStruct) {
 	var ret []string
 	query, explodedArgs, err := builder.BuildRangeChecksumPreparedQuery(
@@ -424,7 +412,7 @@ func (ctx *ChecksumContext) QueryChecksumFunc(db *gosql.DB, databaseName, tableN
 	ch <- newCrc32ResultStruct(ret, nil)
 }
 
-// DataChecksumByCount 比较源表和目标表的总记录数，如果IsSuperSetAsEqual为false则只有记录数相等才认为核平，否则源表记录数少于等于目标表则认为核平，返回是否核平以及是否需要继续核对
+// DataChecksumByCount compares the total row counts of the source and target tables. With IsSuperSetAsEqual=false only equal counts pass; otherwise source <= target also passes. Returns whether the counts match and whether further checking is needed.
 func (ctx *ChecksumContext) DataChecksumByCount() (isTableCountEqual bool, isMoreCheckNeeded bool, err error) {
 	SourceQueryTableCount := fmt.Sprintf("select /* dataChecksum */ count(*) from %s.%s", types.EscapeName(ctx.PerTableContext.SourceDatabaseName), types.EscapeName(ctx.PerTableContext.SourceTableName))
 	TargetQueryTableCount := fmt.Sprintf("select /* dataChecksum */ count(*) from %s.%s", types.EscapeName(ctx.PerTableContext.TargetDatabaseName), types.EscapeName(ctx.PerTableContext.TargetTableName))

--- a/pkg/checksum/timecolumn.go
+++ b/pkg/checksum/timecolumn.go
@@ -127,7 +127,7 @@ func (ctx *ChecksumContext) IterationTimeRangeQueryChecksum() (isChunkChecksumEq
 		duration = time.Since(startTime)
 	}()
 
-	// 计算CRC32XOR聚合值，还是逐行CRC32值
+	// checkLevel 1 = aggregated CRC32XOR, 2 = per-row CRC32 values
 	var checkLevel int64 = 1
 	if ctx.Context.IsSuperSetAsEqual {
 		checkLevel = 2
@@ -153,7 +153,7 @@ func (ctx *ChecksumContext) IterationTimeRangeQueryChecksum() (isChunkChecksumEq
 	return false, duration, nil
 }
 
-// queryTimeRangeChecksumFunc 获取当前时间分批的checksum结果(聚合CRC32XOR 或者 逐行CRC32)
+// queryTimeRangeChecksumFunc fetches the checksum result for the current time chunk (aggregated CRC32XOR or per-row CRC32)
 func (ctx *ChecksumContext) queryTimeRangeChecksumFunc(db *gosql.DB, databaseName, tableName string, checkLevel int64, ch chan *crc32ResultStruct) {
 	var ret []string
 	query, err := builder.BuildTimeRangeChecksumSQL(
@@ -190,7 +190,7 @@ func (ctx *ChecksumContext) queryTimeRangeChecksumFunc(db *gosql.DB, databaseNam
 	ch <- newCrc32ResultStruct(ret, nil)
 }
 
-// isOrderedSubset 判断有序集subset是否superset的子集
+// isOrderedSubset reports whether subset is contained in superset, respecting order
 func isOrderedSubset(subset []string, superset []string) bool {
 	startIndex := 0
 	for i := 0; i < len(subset); i++ {

--- a/pkg/timerange/checksum_time_range.go
+++ b/pkg/timerange/checksum_time_range.go
@@ -23,7 +23,7 @@ func NewTimeRangeAdapter(ctx *checksum.ChecksumContext) *TimeRangeAdapter {
 	}
 }
 
-// EstimateTableRowsViaExplain 获取满足TimeRange核对条件的估算行数
+// EstimateTableRowsViaExplain estimates the number of rows matching the time-range check
 func (a *TimeRangeAdapter) EstimateTableRowsViaExplain() (estimatedRows int, err error) {
 	ctx := a.Context
 	query := fmt.Sprintf(`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -115,7 +115,7 @@ func NewBaseContext() *BaseContext {
 	}
 }
 
-// SetChunkSize 设置chunksize范围：10-100000
+// SetChunkSize clamps and stores the chunk size within the allowed range 10-100000
 func (ctx *BaseContext) SetChunkSize(chunkSize int64) {
 	if chunkSize < 10 {
 		chunkSize = 10
@@ -126,7 +126,7 @@ func (ctx *BaseContext) SetChunkSize(chunkSize int64) {
 	atomic.StoreInt64(&ctx.ChunkSize, chunkSize)
 }
 
-// SetDefaultNumRetries 设置最大重试次数,默认10
+// SetDefaultNumRetries sets the maximum number of retries (default 10); non-positive values are ignored
 func (ctx *BaseContext) SetDefaultNumRetries(retries int64) {
 	ctx.throttleMutex.Lock()
 	defer ctx.throttleMutex.Unlock()
@@ -135,7 +135,7 @@ func (ctx *BaseContext) SetDefaultNumRetries(retries int64) {
 	}
 }
 
-// SetLogLevel 设置日志级别
+// SetLogLevel configures the log level and output destination
 func (ctx *BaseContext) SetLogLevel(debug bool, logFile string) {
 	ctx.Log.SetLevel(log.InfoLevel)
 	if debug {
@@ -152,7 +152,7 @@ func (ctx *BaseContext) SetLogLevel(debug bool, logFile string) {
 	}
 }
 
-// SetSpecifiedDatetimeRange 设置按时间字段核对的起止时间
+// SetSpecifiedDatetimeRange parses and validates the begin/end times for time-column checks
 func (ctx *BaseContext) SetSpecifiedDatetimeRange(specifiedTimeBegin, specifiedTimeEnd string) (err error) {
 	if specifiedTimeBegin != "" {
 		if ctx.SpecifiedDatetimeRangeBegin, err = time.ParseInLocation("2006-01-02 15:04:05", specifiedTimeBegin, time.Local); err != nil {
@@ -185,7 +185,7 @@ func (ctx *BaseContext) GetDBUri(databaseName string) (string, string) {
 	return sourceDBUri, targetDBUri
 }
 
-// InitDB 建立数据库连接
+// InitDB opens the source and target database connections
 func (ctx *BaseContext) InitDB() (err error) {
 	databaseName := "information_schema"
 	sourceDBUri, targetDBUri := ctx.GetDBUri(databaseName)
@@ -211,7 +211,7 @@ func (ctx *BaseContext) InitDB() (err error) {
 	return nil
 }
 
-// CloseDB 关闭数据库连接
+// CloseDB closes the source and target database connections
 func (ctx *BaseContext) CloseDB() {
 	ctx.TargetDB.Close()
 	ctx.SourceDB.Close()
@@ -411,7 +411,7 @@ type ColumnValues struct {
 	ValuesPointers []interface{}
 }
 
-// NewColumnValues 将abstractValues的值复制到ValuesPointers
+// NewColumnValues creates a ColumnValues whose ValuesPointers reference its abstract values, ready for sql.Rows.Scan
 func NewColumnValues(length int) *ColumnValues {
 	result := &ColumnValues{
 		abstractValues: make([]interface{}, length),
@@ -438,12 +438,10 @@ func (cv *ColumnValues) AbstractValues() []interface{} {
 	return cv.abstractValues
 }
 
-// StringColumn 返回二进制对应的ASCII字符串
+// StringColumn renders the value at the given index as text; driver byte slices are converted to strings
 func (cv *ColumnValues) StringColumn(index int) string {
 	val := cv.AbstractValues()[index]
-	// uint8 the set of all unsigned  8-bit integers (0 to 255),等同于byte
 	if ints, ok := val.([]uint8); ok {
-		// string([]uint8) 返回byte对应的字符串
 		return string(ints)
 	}
 	return fmt.Sprintf("%+v", val)


### PR DESCRIPTION
## Summary

Repo-wide cleanup converting every remaining Chinese comment and doc line (137 lines across 6 Go files, plus the README) to English. No functional changes.

- **Go code**: every doc comment translated; informative inline comments kept and translated (connection-leak rationale around `rows.Close()`, the two-pass chunk-boundary logic, `>=` vs `>` range-sign semantics, the `GROUP_CONCAT` session caveat). Inline comments that merely restated the following line of code were dropped rather than translated.
- **README**: removed the Chinese title suffix, the duplicate Chinese description paragraph, and the parenthetical Chinese in the feature bullets — all duplicated adjacent English content.

## Verification

- Translation done via a mapping script that fails on any unrecognized line, so nothing slipped through untranslated.
- Final repo-wide grep for CJK characters returns zero matches.
- `go build`, `go vet`, `gofmt`, and `go test ./...` all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)